### PR TITLE
Bug fix: fix definition of d2h in imaging notebooks

### DIFF
--- a/cosi_2016_balloon_data/imaging/COSIpy_RL_Imaging_Crab_Balloon.ipynb
+++ b/cosi_2016_balloon_data/imaging/COSIpy_RL_Imaging_Crab_Balloon.ipynb
@@ -364,7 +364,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Determine the int value of pixel indexes that have non-zero values\n",
+    "# Determine the int value of pixel indexes that have non-zero values\n",
     "nonzero_idx = background.calc_this[ebin]\n",
     "nonzero_idx_num = nonzero_idx.shape[0]"
    ]
@@ -473,7 +473,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h3>Translating the sponse in the Compton Data Space coordinates to the sky</h3>"
+    "<h3>Translating the response in the Compton Data Space coordinates to the sky</h3>"
    ]
   },
   {
@@ -487,7 +487,7 @@
     "    n_l,\n",
     "    analysis.dataset.phis.n_phi_bins*\\\n",
     "    analysis.dataset.fisbels.n_fisbel_bins,\n",
-    "    10)[:,:,nonzero_idx,ebin]"
+    "    analysis.dataset.energies.n_energy_bins)[:,:,nonzero_idx,ebin]"
    ]
   },
   {
@@ -521,7 +521,7 @@
     "    dt=pointing.dtpoins,\n",
     "    n_hours=analysis.dataset.times.n_ph,\n",
     "    binsize=6.,\n",
-    "    #cut=90.,\n",
+    "    cut=90.,\n",
     "    altitude_correction=False,\n",
     "    al=np.ones(len(pointing.dtpoins)))"
    ]
@@ -752,7 +752,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h1>Richardson-Lucy algorithm (individual step explaination included in code):</h1>"
+    "<h1>Richardson-Lucy algorithm (individual step explanation included in code):</h1>"
    ]
   },
   {
@@ -770,7 +770,7 @@
     "bg_cuts, idx_arr, Ncuts = background.bg_cuts, background.idx_arr, background.Ncuts\n",
     "\n",
     "# Number of RL iterations (100 iterations is recommended)\n",
-    "iterations = 10\n",
+    "iterations = 100\n",
     "\n",
     "# Scalling factor for the 'Delta map', values of either 1000 or 2000 are recommended\n",
     "afl_scl = 1000.\n",
@@ -1092,11 +1092,18 @@
     "\n",
     "plt.legend()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1110,7 +1117,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/cosi_2016_balloon_data/spectral-fit/spectral_fit.ipynb
+++ b/cosi_2016_balloon_data/spectral-fit/spectral_fit.ipynb
@@ -423,9 +423,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "COSIMain",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "cosimain"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -437,7 +437,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/cosipy-classic/response_dc1.py
+++ b/cosipy-classic/response_dc1.py
@@ -41,7 +41,7 @@ class SkyResponse:
 
         if from_saved_file:
             # read everything in (very large in many cases)
-            print('Reading complete continuum response.')
+            print('Reading response.')
             self.LoadRegularBinnedMEGAlibResponse()
             print('Done.\n')
 

--- a/imaging/RL-DataChallenge-511keV_10xFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-511keV_10xFlux-Ling.ipynb
@@ -586,7 +586,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Number of time bins (should be the first dimension of the response)"
+    "### Number of time bins"
    ]
   },
   {

--- a/imaging/RL-DataChallenge-511keV_10xFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-511keV_10xFlux-Ling.ipynb
@@ -123,8 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Can print the number of time bins, the width of each time bin, and the total time\n",
-    "print(analysis1.dataset.times.n_time_bins)\n",
+    "# Can print the width of each time bin and the total time\n",
     "print(analysis1.dataset.times.times_wid)\n",
     "print(analysis1.dataset.times.total_time)"
    ]
@@ -163,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# definition of poitings (balloon stability + Earth rotation)\n",
+    "# definition of pointings (balloon stability + Earth rotation)\n",
     "pointing1 = Pointing(dataset=analysis1.dataset,)"
    ]
   },
@@ -473,7 +472,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cut = 90 # This mirrors the earth horizon cut in the response\n",
+    "cut = 90 \n",
     "sky_response_scaled = get_image_response_from_pixelhit_general(\n",
     "    Response=sky_response_CDS,\n",
     "    zenith=zensgrid,\n",
@@ -596,7 +595,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d2h = analysis1.dataset.times.n_time_bins\n",
+    "d2h = analysis1.dataset.binned_data.shape[0]\n",
     "d2h"
    ]
   },
@@ -727,7 +726,7 @@
    "source": [
     "# Richardson-Lucy algorithm\n",
     "\n",
-    "## Individual steps are explained in code.\n",
+    "## Individual steps are explained in the code.\n",
     "The steps follow the algorithm as outlined in [Knodlseder et al. 1999](https://ui.adsabs.harvard.edu/abs/1999A%26A...345..813K/abstract). Refer to that paper for a mathematical description of the algorithm.\n",
     "\n",
     "The total memory used during these iterations is about 74 GB!! You might not be able to do much else with your machine while this is running. "
@@ -922,7 +921,7 @@
     "        init = {}\n",
     "        init['flux'] = np.array([1.,afl/2.])\n",
     "        init['Abg'] = np.repeat(fitted_bg, Ncuts) # can play with this\n",
-    "        \n",
+    "        a\n",
     "        # fit: might take some time but it shouldn't be more than a minute\n",
     "        op2D = model_multimap.optimizing(data=data_multimap,init=init,as_vector=False,verbose=True,\n",
     "                                                tol_rel_grad=1e3,tol_obj=1e-20)\n",

--- a/imaging/RL-DataChallenge-Al26_10xFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-Al26_10xFlux-Ling.ipynb
@@ -18,25 +18,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Welcome to JupyROOT 6.24/06\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/ckierans/Software/COSItools/COSItools/external/root_v6.24.06/lib/ROOT/_facade.py:150: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
-      "  return _orig_ihook(name, *args, **kwds)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from COSIpy_dc1 import *\n",
     "import response_dc1\n",
@@ -58,13 +42,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "data_dir = '../data_products' # directory containing data & response files\n",
     "filename = 'Al26_10xFlux_and_Ling.inc1.id1.extracted.tra.gz'# Al-26 with Ling BG\n",
-    "response_filename = data_dir + '1809keV_imaging_response.npz' # detector response\n",
+    "response_filename = data_dir + '/1809keV_imaging_response.npz' # detector response\n",
     "background_filename = data_dir + '/Scaled_Ling_BG_1x.npz' # background response\n",
     "background_mode = 'from file'"
    ]
@@ -79,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,8 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Can print the number of time bins, the width of each time bin, and the total time\n",
-    "print(analysis1.dataset.times.n_time_bins)\n",
+    "# Can print the width of each time bin and the total time\n",
     "print(analysis1.dataset.times.times_wid)\n",
     "print(analysis1.dataset.times.total_time)"
    ]
@@ -489,7 +472,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cut = 90 # This mirrors the earth horizon cut in the response\n",
+    "cut = 90 \n",
     "sky_response_scaled = get_image_response_from_pixelhit_general(\n",
     "    Response=sky_response_CDS,\n",
     "    zenith=zensgrid,\n",
@@ -612,7 +595,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d2h = analysis1.dataset.times.n_time_bins\n",
+    "d2h = analysis1.dataset.binned_data.shape[0]\n",
     "d2h"
    ]
   },
@@ -706,7 +689,7 @@
     "    # compile model (if not yet compiled):\n",
     "    model_multimap = pystan.StanModel('stanmodel.stan')\n",
     "\n",
-    "    with open(data_dir + 'stanmodel.pkl', 'wb') as f:\n",
+    "    with open('stanmodel.pkl', 'wb') as f:\n",
     "        pickle.dump(model_multimap, f)"
    ]
   },
@@ -818,7 +801,7 @@
    "source": [
     "# Richardson-Lucy algorithm\n",
     "\n",
-    "## Individual steps are explained in code.\n",
+    "## Individual steps are explained in the code.\n",
     "The steps follow the algorithm as outlined in [Knodlseder et al. 1999](https://ui.adsabs.harvard.edu/abs/1999A%26A...345..813K/abstract). Refer to that paper for a mathematical description of the algorithm.\n",
     "\n",
     "The total memory used during these iterations is about 74 GB!! You might not be able to do much else with your machine while this is running. "

--- a/imaging/RL-DataChallenge-Al26_10xFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-Al26_10xFlux-Ling.ipynb
@@ -586,7 +586,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Number of time bins (should be the first dimension of the response)"
+    "### Number of time bins"
    ]
   },
   {

--- a/imaging/RL-DataChallenge-Point_Sources-10XFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-Point_Sources-10XFlux-Ling.ipynb
@@ -123,8 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Can print the number of time bins, the width of each time bin, and the total time\n",
-    "print(analysis1.dataset.times.n_time_bins)\n",
+    "# Can print the width of each time bin and the total time\n",
     "print(analysis1.dataset.times.times_wid)\n",
     "print(analysis1.dataset.times.total_time)"
    ]
@@ -636,7 +635,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d2h =  analysis1.dataset.times.n_time_bins\n",
+    "d2h = analysis1.dataset.binned_data.shape[0]\n",
     "d2h"
    ]
   },
@@ -737,7 +736,7 @@
     "    # compile model (if not yet compiled):\n",
     "    model_multimap = pystan.StanModel('stanmodel.stan')\n",
     "\n",
-    "    with open(data_dir + 'stanmodel.pkl', 'wb') as f:\n",
+    "    with open('stanmodel.pkl', 'wb') as f:\n",
     "        pickle.dump(model_multimap, f)"
    ]
   },
@@ -770,7 +769,7 @@
    "source": [
     "# Richardson-Lucy algorithm\n",
     "\n",
-    "## Individual steps are explained in code.\n",
+    "## Individual steps are explained in the code.\n",
     "The steps follow the algorithm as outlined in [Knodlseder et al. 1999](https://ui.adsabs.harvard.edu/abs/1999A%26A...345..813K/abstract). Refer to that paper for a mathematical description of the algorithm.\n",
     "\n",
     "The total memory used during these iterations is about 94 GB!! You might not be able to do much else with your machine while this is running."

--- a/imaging/RL-DataChallenge-Point_Sources-10XFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-Point_Sources-10XFlux-Ling.ipynb
@@ -626,7 +626,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Number of time bins (should be the first dimension of the response)"
+    "### Number of time bins "
    ]
   },
   {

--- a/spectral-fit/spectral_fit.ipynb
+++ b/spectral-fit/spectral_fit.ipynb
@@ -659,9 +659,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "COSIMain",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "cosimain"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -673,7 +673,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I found a bug in the simulation imaging notebooks which only appeared when imaging source-only 511 keV, 26Al, and point sources. Because all of the recent testing has been done with the source+Ling files, I didn't notice it until today.

During the internal COSIpy working group review, `d2h = n_time_bins` (where `n_time_bins = analysis1.dataset.binned_data.shape[0]`), was changed to `d2h = analysis1.dataset.times.n_time_bins`. These aren’t the same in the source-only simulations and the bug produces an error further down in the notebook:
> ValueError                                Traceback (most recent call last)
> Cell In [31], line 2
>       1 print('ebin: ',ebin)
> ----> 2 dataset = analysis1.dataset.binned_data[:,ebin,:,:].reshape(d2h,
>       3                                                             analysis1.dataset.phis.n_phi_bins*analysis1.dataset.fisbels.n_fisbel_bins)[:,nonzero_idx]
> 
> ValueError: cannot reshape array of size 36685800 into shape (2210,34350)

I fixed this by redefining d2h as `d2h = analysis1.dataset.binned_data.shape[0]`.

To eliminate confusion about these different ways of expressing the number of time bins, I also removed text at the beginning of the notebooks which incorrectly calls out `analysis1.dataset.times.n_time_bins` as the number of time bins. @tsiegert thinks that this object is an intra-time-bin number used to weight the response within one DeltaT; it isn't relevant here.

I also made a few typo fixes and edited a print statement in `response_dc1.py` to say "Reading response." instead of always saying "Reading complete continuum response."