### PR TITLE
Wrap pystan import in try/except

### DIFF
--- a/imaging/RL-DataChallenge-511keV_10xFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-511keV_10xFlux-Ling.ipynb
@@ -27,7 +27,15 @@
     "from COSIpy_tools_dc1 import *\n",
     "\n",
     "import pickle\n",
-    "import pystan"
+    "\n",
+    "# If pystan exists, import it. If not, proceed anyway.\n",
+    "# See data challenge README for more information.\n",
+    "pystan_exists = True\n",
+    "try:\n",
+    "    import pystan\n",
+    "except ImportError as error:\n",
+    "    pystan_exists = False\n",
+    "    print('Cannot import module.', error)"
    ]
   },
   {
@@ -681,18 +689,21 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    #read stanmodel.pkl (if already compiled)\n",
-    "    model_multimap = pickle.load(open('stanmodel.pkl', 'rb'))\n",
+    "if pystan_exists:\n",
+    "    try:\n",
+    "        #read stanmodel.pkl (if already compiled)\n",
+    "        model_multimap = pickle.load(open('stanmodel.pkl', 'rb'))\n",
     "\n",
-    "except:\n",
-    "    print('Model not yet compiled, doing that now (might take a while).')\n",
-    "    \n",
-    "    # compile model (if not yet compiled):\n",
-    "    model_multimap = pystan.StanModel('stanmodel.stan')\n",
+    "    except:\n",
+    "        print('Model not yet compiled, doing that now (might take a while).')\n",
     "\n",
-    "    with open('stanmodel.pkl', 'wb') as f:\n",
-    "        pickle.dump(model_multimap, f)"
+    "        # compile model (if not yet compiled):\n",
+    "        model_multimap = pystan.StanModel('stanmodel.stan')\n",
+    "\n",
+    "        with open('stanmodel.pkl', 'wb') as f:\n",
+    "            pickle.dump(model_multimap, f)\n",
+    "else:\n",
+    "    print('pystan is not loaded. Skipping this cell.')"
    ]
   },
   {
@@ -729,7 +740,9 @@
     "## Individual steps are explained in the code.\n",
     "The steps follow the algorithm as outlined in [Knodlseder et al. 1999](https://ui.adsabs.harvard.edu/abs/1999A%26A...345..813K/abstract). Refer to that paper for a mathematical description of the algorithm.\n",
     "\n",
-    "The total memory used during these iterations is about 74 GB!! You might not be able to do much else with your machine while this is running. "
+    "The total memory used during these iterations is about 74 GB!! You might not be able to do much else with your machine while this is running. \n",
+    "\n",
+    "Note: If pystan is not loaded, the algorithm will print \"Fit failed! proceeding without acceleration\". Proceed with the iterations anyway."
    ]
   },
   {
@@ -942,6 +955,7 @@
     "    except:\n",
     "        # if the fit failed...\n",
     "        # this shouldn't happen too often (or at all)\n",
+    "        # This will happen if pystan is not loaded. Proceed anyway.\n",
     "        print('############## Fit failed! proceeding without acceleration ##############')\n",
     "        map_new = map_old + delta_map_tot_old\n",
     "        expectation_new = expectation_old + conv_delta_map_tot\n",
@@ -1141,7 +1155,7 @@
     "    ims.append([img, ttl])\n",
     "\n",
     "cbar = fig.colorbar(img, orientation='horizontal')\n",
-    "cbar.ax.set_xlabel(r'Arbitrary Units')\n",
+    "cbar.ax.set_xlabel(r'[Arbitrary Units]')\n",
     "    \n",
     "\n",
     "# Can save a sole image as a PDF \n",

--- a/imaging/RL-DataChallenge-Al26_10xFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-Al26_10xFlux-Ling.ipynb
@@ -27,7 +27,16 @@
     "from COSIpy_tools_dc1 import *\n",
     "\n",
     "import pickle\n",
-    "import pystan"
+    "\n",
+    "# If pystan exists, import it. If not, please use a machine with pystan.\n",
+    "# See data challenge README for more information.\n",
+    "pystan_exists = True\n",
+    "try:\n",
+    "    import pystan\n",
+    "except ImportError as error:\n",
+    "    pystan_exists = False\n",
+    "    print('Cannot import module.', error)\n",
+    "    print('26Al imaging requires pystan. Please use a machine with pystan installed.')"
    ]
   },
   {
@@ -679,18 +688,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    #read stanmodel.pkl (if already compiled)\n",
-    "    model_multimap = pickle.load(open('stanmodel.pkl', 'rb'))\n",
+    "if pystan_exists:\n",
+    "    try:\n",
+    "        #read stanmodel.pkl (if already compiled)\n",
+    "        model_multimap = pickle.load(open('stanmodel.pkl', 'rb'))\n",
     "\n",
-    "except:\n",
-    "    print('Model not yet compiled, doing that now (might take a while).')\n",
-    "    \n",
-    "    # compile model (if not yet compiled):\n",
-    "    model_multimap = pystan.StanModel('stanmodel.stan')\n",
+    "    except:\n",
+    "        print('Model not yet compiled, doing that now (might take a while).')\n",
     "\n",
-    "    with open('stanmodel.pkl', 'wb') as f:\n",
-    "        pickle.dump(model_multimap, f)"
+    "        # compile model (if not yet compiled):\n",
+    "        model_multimap = pystan.StanModel('stanmodel.stan')\n",
+    "\n",
+    "        with open('stanmodel.pkl', 'wb') as f:\n",
+    "            pickle.dump(model_multimap, f)\n",
+    "else:\n",
+    "    print('pystan is not loaded. Skipping this cell.')"
    ]
   },
   {
@@ -804,7 +816,9 @@
     "## Individual steps are explained in the code.\n",
     "The steps follow the algorithm as outlined in [Knodlseder et al. 1999](https://ui.adsabs.harvard.edu/abs/1999A%26A...345..813K/abstract). Refer to that paper for a mathematical description of the algorithm.\n",
     "\n",
-    "The total memory used during these iterations is about 74 GB!! You might not be able to do much else with your machine while this is running. "
+    "The total memory used during these iterations is about 74 GB!! You might not be able to do much else with your machine while this is running. \n",
+    "\n",
+    "Note: If pystan is not loaded, the algorithm will print \"Fit failed! proceeding without acceleration\". In the case of point source and 511 keV imaging, proceed anyway. The Al-26 distribution here, however, will not converge properly. Please use a machine with pystan."
    ]
   },
   {
@@ -1017,6 +1031,7 @@
     "    except:\n",
     "        # if the fit failed...\n",
     "        # this shouldn't happen too often (or at all)\n",
+    "        # This will happen if pystan is not loaded. Proceed anyway.\n",
     "        print('############## Fit failed! proceeding without acceleration ##############')\n",
     "        map_new = map_old + delta_map_tot_old\n",
     "        expectation_new = expectation_old + conv_delta_map_tot\n",
@@ -1129,7 +1144,7 @@
    "outputs": [],
    "source": [
     "# Choose an image to plot\n",
-    "idx = its - 1\n"
+    "idx = its\n"
    ]
   },
   {
@@ -1221,7 +1236,7 @@
     "    ims.append([img, ttl])\n",
     "\n",
     "cbar = fig.colorbar(img, orientation='horizontal')\n",
-    "cbar.ax.set_xlabel('Arbitrary Units')\n",
+    "cbar.ax.set_xlabel('[Arbitrary Units]')\n",
     "    \n",
     "\n",
     "# Can save a sole image as a PDF \n",

--- a/imaging/RL-DataChallenge-Point_Sources-10XFlux-Ling.ipynb
+++ b/imaging/RL-DataChallenge-Point_Sources-10XFlux-Ling.ipynb
@@ -27,7 +27,15 @@
     "from COSIpy_tools_dc1 import *\n",
     "\n",
     "import pickle\n",
-    "import pystan"
+    "\n",
+    "# If pystan exists, import it. If not, proceed anyway.\n",
+    "# See data challenge README for more information.\n",
+    "pystan_exists = True\n",
+    "try:\n",
+    "    import pystan\n",
+    "except ImportError as error:\n",
+    "    pystan_exists = False\n",
+    "    print('Cannot import module.', error)"
    ]
   },
   {
@@ -726,18 +734,21 @@
    },
    "outputs": [],
    "source": [
-    "try:\n",
-    "    #read stanmodel.pkl (if already compiled)\n",
-    "    model_multimap = pickle.load(open('stanmodel.pkl', 'rb'))\n",
+    "if pystan_exists:\n",
+    "    try:\n",
+    "        #read stanmodel.pkl (if already compiled)\n",
+    "        model_multimap = pickle.load(open('stanmodel.pkl', 'rb'))\n",
     "\n",
-    "except:\n",
-    "    print('Model not yet compiled, doing that now (might take a while).')\n",
-    "    \n",
-    "    # compile model (if not yet compiled):\n",
-    "    model_multimap = pystan.StanModel('stanmodel.stan')\n",
+    "    except:\n",
+    "        print('Model not yet compiled, doing that now (might take a while).')\n",
     "\n",
-    "    with open('stanmodel.pkl', 'wb') as f:\n",
-    "        pickle.dump(model_multimap, f)"
+    "        # compile model (if not yet compiled):\n",
+    "        model_multimap = pystan.StanModel('stanmodel.stan')\n",
+    "\n",
+    "        with open('stanmodel.pkl', 'wb') as f:\n",
+    "            pickle.dump(model_multimap, f)\n",
+    "else:\n",
+    "    print('pystan is not loaded. Skipping this cell.')"
    ]
   },
   {
@@ -772,7 +783,9 @@
     "## Individual steps are explained in the code.\n",
     "The steps follow the algorithm as outlined in [Knodlseder et al. 1999](https://ui.adsabs.harvard.edu/abs/1999A%26A...345..813K/abstract). Refer to that paper for a mathematical description of the algorithm.\n",
     "\n",
-    "The total memory used during these iterations is about 94 GB!! You might not be able to do much else with your machine while this is running."
+    "The total memory used during these iterations is about 94 GB!! You might not be able to do much else with your machine while this is running.\n",
+    "\n",
+    "Note: If pystan is not loaded, the algorithm will print \"Fit failed! proceeding without acceleration\". Proceed with the iterations anyway."
    ]
   },
   {
@@ -984,7 +997,8 @@
     "\n",
     "    except:\n",
     "        # if the fit failed...\n",
-    "        # this shouldn't happen too often (or at all)\n",
+    "        # this shouldn't happen too often (or at all). \n",
+    "        # This will happen if pystan is not loaded. Proceed anyway.\n",
     "        print('############## Fit failed! proceeding without acceleration ##############')\n",
     "        map_new = map_old + delta_map_tot_old\n",
     "        expectation_new = expectation_old + conv_delta_map_tot\n",
@@ -1097,7 +1111,7 @@
    "outputs": [],
    "source": [
     "# Choose an image to plot\n",
-    "idx = its - 1\n"
+    "idx = its\n"
    ]
   },
   {
@@ -1184,7 +1198,7 @@
     "    ims.append([img, ttl])\n",
     "\n",
     "cbar = fig.colorbar(img, orientation='horizontal')\n",
-    "cbar.ax.set_xlabel('Arbitrary Units')\n",
+    "cbar.ax.set_xlabel('[Arbitrary Units]')\n",
     "    \n",
     "\n",
     "# Can save a sole image as a PDF \n",


### PR DESCRIPTION
I wrapped `import pystan` in an a try/except block and created a boolean that will skip loading the stan model in a later cell if pystan does not exist.

I also added a couple of comments in the Richardson-Lucy cell explaining that not loading pystan will trigger "Fit failed! proceeding without acceleration" messages.

Let me know if this runs properly on machines which cannot install pystan 2.19.1.1.